### PR TITLE
feature: chat-history

### DIFF
--- a/src/lib/chat_history.js
+++ b/src/lib/chat_history.js
@@ -1,0 +1,22 @@
+var chat_history = []
+
+function add_to_history(user_input, AI_response) {
+    // Adds new entry. //
+    chat_history.push({role: "user", content: user_input});
+    chat_history.push({role: "assistant", content: AI_response});
+
+
+    // Deletes the oldest entry if more entries than 20 found. //
+    if (chat_history.length > 20) {
+        chat_history.shift()
+    }
+}
+
+function retrieve_history() {
+    return chat_history;
+}
+
+module.exports = {
+    add_to_history,
+    retrieve_history
+}

--- a/src/lib/post_request.js
+++ b/src/lib/post_request.js
@@ -1,5 +1,6 @@
 const OpenAI = require("openai");
 const dotenv = require("dotenv");
+const history = require('./chat_history');
 dotenv.config();
 
 const openai = new OpenAI({
@@ -10,9 +11,14 @@ async function main(user_message) {
     try {
         const completion = await openai.chat.completions.create({
             messages: [{role: "system", content: "You are a helpful assistant."},
+                ...history.retrieve_history(),
                 {role: "user", content: user_message}], // make content the user input
-            model: "gpt-3.5-turbo",
+            model: "gpt-4o",
         });
+        
+        // Adds user input and API response to history. //
+        history.add_to_history(user_message, completion.choices[0].message.content);
+
         console.log(completion.choices[0].message.content);
         return (completion.choices[0].message.content);
 


### PR DESCRIPTION
Using arrays, the chat history will be stored as an array that takes a max of 20 entries. 
Has 2 functions: add_to_history, takes 2 parameters to add as entries to history. retrieve_history() which sends history back.

Modifications in /lib/post_request.js for history implementation in API call.
